### PR TITLE
feat: cuda enabled dev container

### DIFF
--- a/.devcontainer/cuda/Dockerfile
+++ b/.devcontainer/cuda/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.6.3-base-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.devcontainer/cuda/Dockerfile
+++ b/.devcontainer/cuda/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.0-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.devcontainer/cuda/Dockerfile
+++ b/.devcontainer/cuda/Dockerfile
@@ -1,0 +1,29 @@
+FROM nvidia/cuda:12.6.0-cudnn-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    curl \
+    wget \
+    git \
+    jq \
+    zip \
+    build-essential \
+    ca-certificates \
+    sudo \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get update && apt-get install -y nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
+RUN npm install -g zx
+
+COPY requirements.txt* /tmp/
+RUN if [ -f /tmp/requirements.txt ]; then pip3 install --no-cache-dir -r /tmp/requirements.txt; fi
+
+RUN echo "devcontainer-cuda" >> /root/.mainrun

--- a/.devcontainer/cuda/devcontainer.json
+++ b/.devcontainer/cuda/devcontainer.json
@@ -1,0 +1,12 @@
+{
+	"name": "Mainrun (CUDA)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "."
+	},
+	"runArgs": ["--gpus", "all"],
+	"hostRequirements": {
+		"gpu": true
+	},
+	"remoteUser": "root"
+}

--- a/.devcontainer/cuda/requirements.txt
+++ b/.devcontainer/cuda/requirements.txt
@@ -1,0 +1,6 @@
+datasets==4.0.0
+matplotlib==3.10.3
+structlog==24.4.0
+tokenizers==0.21.2
+torch==2.7.1
+tqdm==4.67.1

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ nvidia-smi
 
 If it prints your GPU, you're set. `task train` will pick it up automatically.
 
+#### Customising
+
+The CUDA dev container uses NVIDIA's minimal `base` image, which is enough to run the stock PyTorch wheel against your host GPU. If you want to do something fancier (compile CUDA extensions from source, use system cuDNN, build custom kernels, etc.), edit `.devcontainer/cuda/Dockerfile` and swap the base image for a heavier variant (`runtime`, `devel`, or one of the `cudnn` flavours).
+
 ## Key Commands
 You will only need two main commands for this assessment:
 

--- a/README.md
+++ b/README.md
@@ -53,30 +53,27 @@ cat mainrun/logs/baseline.log
 
 ### CUDA-Enabled Dev Container
 
-If you have access to an NVIDIA GPU, you can use the CUDA dev container at `.devcontainer/cuda/` for hardware-accelerated training. It is built on `nvidia/cuda:12.6.0-cudnn-devel-ubuntu22.04` and launches with `--gpus all` so the container has full access to the host's GPUs.
+If you have access to an NVIDIA GPU, you can use the CUDA dev container at `.devcontainer/cuda/` for hardware-accelerated training. It is built on an official NVIDIA CUDA image and launches with `--gpus all` so the container has full access to the host's GPUs.
 
 #### Prerequisites
 
 - A host with an NVIDIA GPU and a recent driver (CUDA 12.6+ compatible).
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed on the host. Without it, the container will fail to start.
-- Docker Desktop on macOS does **not** support GPU passthrough — run on a Linux host (local or remote via VS Code's Remote-SSH) for GPU access.
+- Docker Desktop on macOS does **not** support GPU passthrough. Run on a Linux host (local or remote via VS Code's Remote-SSH) for GPU access.
 
 #### Launching
 
-1. Open the repository in VS Code.
-2. Run **Dev Containers: Reopen in Container** from the command palette.
-3. When prompted, choose the **Mainrun (CUDA)** configuration (this corresponds to `.devcontainer/cuda/`).
+When reopening in the Dev Container, select the **Mainrun (CUDA)** option from the menu.
 
 #### Verifying GPU access
 
-Once inside the container:
+Once inside the container, run:
 
 ```bash
 nvidia-smi
-python3 -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'no gpu')"
 ```
 
-If both report your GPU, you're set — `task train` will pick it up automatically.
+If it prints your GPU, you're set. `task train` will pick it up automatically.
 
 ## Key Commands
 You will only need two main commands for this assessment:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,35 @@ cat mainrun/logs/baseline.log
 # 5. Start optimizing!
 ```
 
+## Optional
+
+### CUDA-Enabled Dev Container
+
+If you have access to an NVIDIA GPU, you can use the CUDA dev container at `.devcontainer/cuda/` for hardware-accelerated training. It is built on `nvidia/cuda:12.6.0-cudnn-devel-ubuntu22.04` and launches with `--gpus all` so the container has full access to the host's GPUs.
+
+#### Prerequisites
+
+- A host with an NVIDIA GPU and a recent driver (CUDA 12.6+ compatible).
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed on the host. Without it, the container will fail to start.
+- Docker Desktop on macOS does **not** support GPU passthrough — run on a Linux host (local or remote via VS Code's Remote-SSH) for GPU access.
+
+#### Launching
+
+1. Open the repository in VS Code.
+2. Run **Dev Containers: Reopen in Container** from the command palette.
+3. When prompted, choose the **Mainrun (CUDA)** configuration (this corresponds to `.devcontainer/cuda/`).
+
+#### Verifying GPU access
+
+Once inside the container:
+
+```bash
+nvidia-smi
+python3 -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'no gpu')"
+```
+
+If both report your GPU, you're set — `task train` will pick it up automatically.
+
 ## Key Commands
 You will only need two main commands for this assessment:
 


### PR DESCRIPTION
### Summary

Provides users who have access to cuda supported GPUs to run natively with dev-container. Helps cut down training time from 30+ minutes with cpu only to a few minutes or less. 

#### CUDA devcontainer option in VSCode 

<img width="640" height="181" alt="Screenshot From 2026-05-29 00-40-43" src="https://github.com/user-attachments/assets/1ef5bb07-ff64-4f73-ab79-a8bf5addea23" />

#### Training loop with cuda device detected 

<img width="1653" height="191" alt="Screenshot From 2026-05-29 01-14-28" src="https://github.com/user-attachments/assets/d6daa5a1-a6fc-47cc-aabd-a5de3d3c401b" />
